### PR TITLE
correct calculation of unstable bars of SMA indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Fixed calculation of `ReturnOverMaxDrawdownCriterion`
 - swapped parameter naming in  `BaseBarSeries#addTrade(final Number tradeVolume, final Number tradePrice)`
 - Aggregation of amount and trades in `VolumeBarBuilder` and `TickBarBuilder`
+- Corrected the calculation of unstable bars of the SMA indicator
 
 ### Changed
 - Use `NetReturnCriterion` in `AverageReturnPerBarCriterion`, `EnterAndHoldCriterion` and `ReturnOverMaxDrawdownCriterion` to avoid optimistic bias of `GrossReturnCriterion`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Added `AmountBarBuilder` to `bars`-package to aggregate bars after a fixed number of amount have been traded
 - Added `CumulativePnL` and `MaximumAbsoluteDrawdownCriterion` to calculate the max drawdown absolute value, and `MaximumDrawdownBarLengthCriterion` to calculate its length
 - Added `MonteCarloMaximumDrawdownCriterion` to estimate drawdown risk distribution by simulating different trade orders
+- Added `CommissionsCriterion` to total the commissions paid across positions and `CommissionsImpactPercentageCriterion` to express how much those costs eat into gross profit
+- Added `MaxConsecutiveLossCriterion`, `MaxConsecutiveProfitCriterion`, `MaxPositionNetLossCriterion` and `MaxPositionNetProfitCriterion` to report the worst loss streaks, best win streaks, and extreme per-position outcomes in a record
+- Added `InPositionPercentageCriterion` to calculate the percentage of the time that a strategy remains invested
 
 ## 0.18 (released May 15, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Fixed calculation of `ReturnOverMaxDrawdownCriterion`
 - swapped parameter naming in  `BaseBarSeries#addTrade(final Number tradeVolume, final Number tradePrice)`
 - Aggregation of amount and trades in `VolumeBarBuilder` and `TickBarBuilder`
+- `PivotPointIndicatorTest` fixed to work also in java 25
 
 ### Changed
 - Use `NetReturnCriterion` in `AverageReturnPerBarCriterion`, `EnterAndHoldCriterion` and `ReturnOverMaxDrawdownCriterion` to avoid optimistic bias of `GrossReturnCriterion`

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/InPositionPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/InPositionPercentageCriterion.java
@@ -1,0 +1,116 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria;
+
+import java.time.temporal.ChronoUnit;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.num.Num;
+
+/**
+ * Analysis criterion that measures the share of time spent in the market.
+ *
+ * <p>
+ * The criterion compares the time covered by open positions to the overall
+ * trading period and expresses it as a percentage.
+ * </p>
+ *
+ * @since 0.19
+ */
+public class InPositionPercentageCriterion extends AbstractAnalysisCriterion {
+
+    /**
+     * Calculates how long a single position stays open relative to the entire
+     * series duration.
+     *
+     * @param series   the bar series providing the trading period
+     * @param position the position to evaluate
+     * @return the percentage of the series duration covered by the position
+     */
+    @Override
+    public Num calculate(BarSeries series, Position position) {
+        var numFactory = series.numFactory();
+        if (series.isEmpty()) {
+            return numFactory.zero();
+        }
+        var totalDuration = totalTradingDuration(series);
+        if (totalDuration == 0) {
+            return numFactory.zero();
+        }
+        var positionDuration = positionDuration(series, position);
+        return numFactory.numOf(positionDuration).dividedBy(numFactory.numOf(totalDuration));
+    }
+
+    /**
+     * Calculates how long the strategy stays invested across all positions in the
+     * trading record.
+     *
+     * @param series        the bar series providing the trading period
+     * @param tradingRecord the trading record containing the positions to evaluate
+     * @return the percentage of the series duration covered by the record's
+     *         positions
+     */
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        var numFactory = series.numFactory();
+        if (series.isEmpty()) {
+            return numFactory.zero();
+        }
+        var totalDuration = totalTradingDuration(series);
+        if (totalDuration == 0 || tradingRecord.getPositionCount() == 0) {
+            return numFactory.zero();
+        }
+        var positionDuration = tradingRecord.getPositions().stream().mapToLong(p -> positionDuration(series, p)).sum();
+        return numFactory.numOf(positionDuration).dividedBy(numFactory.numOf(totalDuration));
+    }
+
+    /**
+     * Indicates whether the first percentage is preferable to the second.
+     *
+     * @param criterionValue1 the first value to compare
+     * @param criterionValue2 the second value to compare
+     * @return {@code true} when the first value is lower (less time in the market)
+     */
+    @Override
+    public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+        return criterionValue1.isLessThan(criterionValue2);
+    }
+
+    private static long totalTradingDuration(BarSeries series) {
+        var start = series.getFirstBar().getBeginTime();
+        var end = series.getLastBar().getEndTime();
+        return ChronoUnit.NANOS.between(start, end);
+    }
+
+    private static long positionDuration(BarSeries series, Position position) {
+        if (position == null || position.isNew() || position.getEntry() == null) {
+            return 0L;
+        }
+        var entryStart = series.getBar(position.getEntry().getIndex()).getBeginTime();
+        var exitIndex = position.isClosed() ? position.getExit().getIndex() : series.getEndIndex();
+        var exitEnd = series.getBar(exitIndex).getEndTime();
+        return ChronoUnit.NANOS.between(entryStart, exitEnd);
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/commissions/CommissionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/commissions/CommissionsCriterion.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.commissions;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.criteria.AbstractAnalysisCriterion;
+import org.ta4j.core.num.Num;
+
+/**
+ * Analysis criterion that sums all commissions paid across positions.
+ *
+ * <p>
+ * The criterion relies on each position cost model to determine the paid
+ * commission and adds them together for a trading record.
+ * </p>
+ *
+ * @since 0.19
+ */
+public class CommissionsCriterion extends AbstractAnalysisCriterion {
+
+    /**
+     * Calculates the commission paid for a single position.
+     *
+     * @param series   the bar series used for number creation
+     * @param position the evaluated position
+     * @return the commission paid for the provided position
+     */
+    @Override
+    public Num calculate(BarSeries series, Position position) {
+        if (position.isClosed()) {
+            var model = position.getEntry().getCostModel();
+            return model.calculate(position);
+        }
+        if (position.isOpened()) {
+            var model = position.getEntry().getCostModel();
+            var finalIndex = series.getEndIndex();
+            return model.calculate(position, finalIndex);
+        }
+        return series.numFactory().zero();
+    }
+
+    /**
+     * Calculates the total commission paid for every position in a trading record.
+     *
+     * @param series        the bar series used for number creation
+     * @param tradingRecord the trading record containing the positions to evaluate
+     * @return the sum of commissions paid for the record
+     */
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        var model = tradingRecord.getTransactionCostModel();
+        var closedPositionsCommissions = tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(model::calculate)
+                .reduce(series.numFactory().zero(), Num::plus);
+
+        var current = tradingRecord.getCurrentPosition();
+        if (current.isOpened()) {
+            var openPositionCommissions = model.calculate(current, tradingRecord.getEndIndex(series));
+            return closedPositionsCommissions.plus(openPositionCommissions);
+        }
+        return closedPositionsCommissions;
+    }
+
+    /**
+     * Indicates whether the first commission value is preferable to the second.
+     *
+     * @param v1 the first value to compare
+     * @param v2 the second value to compare
+     * @return {@code true} when the first value is lower
+     */
+    @Override
+    public boolean betterThan(Num v1, Num v2) {
+        return v1.isLessThan(v2);
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/commissions/CommissionsImpactPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/commissions/CommissionsImpactPercentageCriterion.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.commissions;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.criteria.AbstractAnalysisCriterion;
+import org.ta4j.core.criteria.pnl.GrossProfitLossCriterion;
+import org.ta4j.core.num.Num;
+
+/**
+ * Analysis criterion that measures how much commission reduces gross profit.
+ *
+ * <p>
+ * It expresses the commission impact as the percentage of the gross profit or
+ * loss.
+ * </p>
+ *
+ * @since 0.19
+ */
+public final class CommissionsImpactPercentageCriterion extends AbstractAnalysisCriterion {
+
+    private static final GrossProfitLossCriterion GROSS_PROFIT_LOSS_CRITERION = new GrossProfitLossCriterion();
+    private static final CommissionsCriterion COMMISSION_CRITERION = new CommissionsCriterion();
+
+    /**
+     * Calculates the commission percentage impact for a single position.
+     *
+     * @param s the bar series used for number creation
+     * @param p the evaluated position
+     * @return the percentage of commission relative to gross profit or zero when
+     *         there is no gross profit
+     */
+    @Override
+    public Num calculate(BarSeries s, Position p) {
+        var numFactory = s.numFactory();
+        var zero = numFactory.zero();
+        var entry = p.getEntry();
+        if (entry == null) {
+            return zero;
+        }
+        var gross = p.getGrossProfit().abs();
+        var comm = zero;
+        var model = entry.getCostModel();
+        var transactionCost = model.calculate(p);
+        if (transactionCost != null) {
+            comm = transactionCost.abs();
+        }
+        return gross.isZero() ? zero : comm.dividedBy(gross);
+    }
+
+    /**
+     * Calculates the commission percentage impact for all positions in a trading
+     * record.
+     *
+     * @param s the bar series used for number creation
+     * @param r the trading record containing the positions to evaluate
+     * @return the percentage of commission relative to the record gross profit or
+     *         zero when there is no gross profit
+     */
+    @Override
+    public Num calculate(BarSeries s, TradingRecord r) {
+        var gross = GROSS_PROFIT_LOSS_CRITERION.calculate(s, r).abs();
+        var comm = COMMISSION_CRITERION.calculate(s, r).abs();
+        var numFactory = s.numFactory();
+        return gross.isZero() ? numFactory.zero() : comm.dividedBy(gross);
+    }
+
+    /**
+     * Indicates whether the first percentage is preferable to the second.
+     *
+     * @param a the first value to compare
+     * @param b the second value to compare
+     * @return {@code true} when the first value is lower
+     * @since 0.19
+     */
+    @Override
+    public boolean betterThan(Num a, Num b) {
+        return a.isLessThan(b);
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AbstractConsecutivePnlCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AbstractConsecutivePnlCriterion.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.criteria.AbstractAnalysisCriterion;
+import org.ta4j.core.num.Num;
+
+/**
+ * Base class for consecutive PnL criteria.
+ * <p>
+ * It computes the best cumulative streak over a {@link TradingRecord}:
+ * subclasses define what counts as a contributing position (via
+ * {@link #accepts(Num)}) and how to choose the preferred streak value (via
+ * {@link #preferForStreak(Num, Num)}).
+ *
+ * @since 0.19
+ */
+public abstract class AbstractConsecutivePnlCriterion extends AbstractAnalysisCriterion {
+
+    /**
+     * Positive for profit-streaks, negative for loss-streaks.
+     */
+    protected abstract boolean accepts(Num profit);
+
+    /**
+     * For profit-streaks choose greater, for loss-streaks choose smaller (more
+     * severe).
+     */
+    protected abstract boolean preferForStreak(Num candidate, Num best);
+
+    /**
+     * Returns the profit or loss of the position.
+     *
+     * @param series   the bar series used for number creation
+     * @param position the evaluated position
+     * @return the profit or loss of the position, or zero when it is not a profit
+     *         or a loss
+     */
+    @Override
+    public Num calculate(BarSeries series, Position position) {
+        var zero = series.numFactory().zero();
+        if (position.isNew() || position.getEntry() == null) {
+            return zero;
+        }
+        var profit = position.getProfit();
+        return accepts(profit) ? profit : zero;
+    }
+
+    /**
+     * Determines the biggest cumulative profit or loss across consecutive winning
+     * or losing positions in the trading record.
+     *
+     * @param series        the bar series used for number creation
+     * @param tradingRecord the trading record containing the positions to scan
+     * @return the best or worst consecutive profit or loss or zero when there are
+     *         no wins or losses
+     */
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        var zero = series.numFactory().zero();
+        var current = zero;
+        var best = zero;
+
+        for (var position : tradingRecord.getPositions()) {
+            var contribution = position.isClosed() ? calculate(series, position) : zero;
+            if (!contribution.isZero()) {
+                current = current.plus(contribution);
+                if (preferForStreak(current, best)) {
+                    best = current;
+                }
+            } else {
+                current = zero;
+            }
+        }
+        return best;
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/MaxConsecutiveLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/MaxConsecutiveLossCriterion.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import org.ta4j.core.num.Num;
+
+/**
+ * Analysis criterion that finds the largest string of consecutive losing
+ * positions.
+ *
+ * <p>
+ * The criterion sums the losses of each losing streak and returns the lowest
+ * value.
+ * </p>
+ *
+ * @since 0.19
+ */
+public class MaxConsecutiveLossCriterion extends AbstractConsecutivePnlCriterion {
+
+    @Override
+    protected boolean accepts(Num profit) {
+        return profit.isNegative();
+    }
+
+    @Override
+    protected boolean preferForStreak(Num candidate, Num best) {
+        return candidate.isLessThan(best);
+    }
+
+    /**
+     * Indicates whether the first loss streak is preferable to the second.
+     *
+     * @param a the first value to compare
+     * @param b the second value to compare
+     * @return {@code true} when the first value is higher (a smaller loss)
+     */
+    @Override
+    public boolean betterThan(Num a, Num b) {
+        return a.isGreaterThan(b);
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/MaxConsecutiveProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/MaxConsecutiveProfitCriterion.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import org.ta4j.core.num.Num;
+
+/**
+ * Analysis criterion that finds the most profitable streak of consecutive
+ * positions.
+ *
+ * <p>
+ * The criterion sums profits across positive positions and returns the highest
+ * value reached.
+ * </p>
+ *
+ * @since 0.19
+ */
+public class MaxConsecutiveProfitCriterion extends AbstractConsecutivePnlCriterion {
+
+    @Override
+    protected boolean accepts(Num profit) {
+        return profit.isPositive();
+    }
+
+    @Override
+    protected boolean preferForStreak(Num candidate, Num best) {
+        return candidate.isGreaterThan(best);
+    }
+
+    /**
+     * Indicates whether the first profit streak is preferable to the second.
+     *
+     * @param a the first value to compare
+     * @param b the second value to compare
+     * @return {@code true} when the first value is higher (a larger gain)
+     */
+    @Override
+    public boolean betterThan(Num a, Num b) {
+        return a.isGreaterThan(b);
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/MaxPositionNetLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/MaxPositionNetLossCriterion.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.criteria.AbstractAnalysisCriterion;
+import org.ta4j.core.num.Num;
+
+/**
+ * Analysis criterion that identifies the worst net loss among closed positions.
+ *
+ * <p>
+ * The criterion returns the most negative profit value found within a trading
+ * record.
+ * </p>
+ *
+ * @since 0.19
+ */
+public final class MaxPositionNetLossCriterion extends AbstractAnalysisCriterion {
+
+    /**
+     * Returns the net profit of the provided position.
+     *
+     * @param barSeries the bar series used for number creation
+     * @param position  the evaluated position
+     * @return the net profit, which will be negative for a loss
+     */
+    @Override
+    public Num calculate(BarSeries barSeries, Position position) {
+        if (position.isNew() || position.getEntry() == null) {
+            return barSeries.numFactory().zero();
+        }
+        return position.getProfit();
+    }
+
+    /**
+     * Finds the largest net loss among all closed positions in the trading record.
+     *
+     * @param barSeries     the bar series used for number creation
+     * @param tradingRecord the trading record containing the positions to scan
+     * @return the most negative profit value or zero when every position is
+     *         profitable or break-even
+     */
+    @Override
+    public Num calculate(BarSeries barSeries, TradingRecord tradingRecord) {
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(Position::getProfit)
+                .filter(Num::isNegative)
+                .min(Num::compareTo)
+                .orElse(barSeries.numFactory().zero());
+    }
+
+    /**
+     * Indicates whether the first loss value is preferable to the second.
+     *
+     * @param a the first value to compare
+     * @param b the second value to compare
+     * @return {@code true} when the first value is higher (a smaller loss)
+     */
+    @Override
+    public boolean betterThan(Num a, Num b) {
+        return a.isGreaterThan(b);
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/MaxPositionNetProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/MaxPositionNetProfitCriterion.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.criteria.AbstractAnalysisCriterion;
+import org.ta4j.core.num.Num;
+
+/**
+ * Analysis criterion that identifies the best net profit among closed
+ * positions.
+ *
+ * <p>
+ * The criterion returns the highest profit value found within a trading record.
+ * </p>
+ *
+ * @since 0.19
+ */
+public final class MaxPositionNetProfitCriterion extends AbstractAnalysisCriterion {
+
+    /**
+     * Returns the net profit of the provided position.
+     *
+     * @param s the bar series used for number creation
+     * @param p the evaluated position
+     * @return the net profit of the position
+     */
+    @Override
+    public Num calculate(BarSeries s, Position p) {
+        if (p.isNew() || p.getEntry() == null) {
+            return s.numFactory().zero();
+        }
+        return p.getProfit();
+    }
+
+    /**
+     * Finds the largest net profit among all closed positions in the trading
+     * record.
+     *
+     * @param barSeries     the bar series used for number creation
+     * @param tradingRecord the trading record containing the positions to scan
+     * @return the highest profit value or zero when no position ends in profit
+     */
+    @Override
+    public Num calculate(BarSeries barSeries, TradingRecord tradingRecord) {
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(Position::getProfit)
+                .filter(Num::isPositive)
+                .max(Num::compareTo)
+                .orElse(barSeries.numFactory().zero());
+    }
+
+    /**
+     * Indicates whether the first profit value is preferable to the second.
+     *
+     * @param a the first value to compare
+     * @param b the second value to compare
+     * @return {@code true} when the first value is higher
+     */
+    @Override
+    public boolean betterThan(Num a, Num b) {
+        return a.isGreaterThan(b);
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/SMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/SMAIndicator.java
@@ -37,7 +37,8 @@ import org.ta4j.core.num.Num;
 public class SMAIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private RunningTotalIndicator previousSum;
+    private final Indicator<Num> indicator;
+    private final RunningTotalIndicator previousSum;
 
     /**
      * Constructor.
@@ -48,6 +49,7 @@ public class SMAIndicator extends CachedIndicator<Num> {
     public SMAIndicator(Indicator<Num> indicator, int barCount) {
         super(indicator);
         this.previousSum = new RunningTotalIndicator(indicator, barCount);
+        this.indicator = indicator;
         this.barCount = barCount;
     }
 
@@ -65,7 +67,7 @@ public class SMAIndicator extends CachedIndicator<Num> {
     /** @return {@link #barCount} */
     @Override
     public int getCountOfUnstableBars() {
-        return barCount;
+        return indicator.getCountOfUnstableBars() + barCount;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/SMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/SMAIndicator.java
@@ -67,7 +67,7 @@ public class SMAIndicator extends CachedIndicator<Num> {
     /** @return {@link #barCount} */
     @Override
     public int getCountOfUnstableBars() {
-        return indicator.getCountOfUnstableBars() + barCount;
+        return indicator.getCountOfUnstableBars() + barCount - 1;
     }
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/InPositionPercentageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/InPositionPercentageCriterionTest.java
@@ -1,0 +1,162 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+import org.ta4j.core.Trade;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+public class InPositionPercentageCriterionTest extends AbstractCriterionTest {
+
+    public InPositionPercentageCriterionTest(NumFactory numFactory) {
+        super(params -> new InPositionPercentageCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsPercentageForClosedPosition() {
+        var series = buildSeries(5, Duration.ofHours(1));
+        var amount = numFactory.one();
+        var entry = Trade.buyAt(1, series.getBar(1).getClosePrice(), amount);
+        var exit = Trade.sellAt(3, series.getBar(3).getClosePrice(), amount);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        var result = criterion.calculate(series, position);
+
+        var totalDuration = totalDuration(series);
+        var positionDuration = positionDuration(series, entry.getIndex(), exit.getIndex());
+        var expectedPercentage = getExpectedPercentage(totalDuration, positionDuration);
+        var expected = numFactory.numOf(expectedPercentage);
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateReturnsPercentageForOpenPosition() {
+        var series = buildSeries(5, Duration.ofHours(1));
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+        record.enter(3, series.getBar(3).getClosePrice(), amount);
+        var openPosition = record.getCurrentPosition();
+
+        var criterion = getCriterion();
+        var result = criterion.calculate(series, openPosition);
+
+        var totalDuration = totalDuration(series);
+        var positionDuration = positionDuration(series, openPosition.getEntry().getIndex(), series.getEndIndex());
+        var expectedPercentage = getExpectedPercentage(totalDuration, positionDuration);
+        var expected = numFactory.numOf(expectedPercentage);
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateAggregatesDurationsAcrossRecord() {
+        var series = buildSeries(5, Duration.ofHours(1));
+        var record = new BaseTradingRecord();
+        var amount = numFactory.one();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        record.exit(1, series.getBar(1).getClosePrice(), amount);
+
+        record.enter(3, series.getBar(3).getClosePrice(), amount);
+        record.exit(4, series.getBar(4).getClosePrice(), amount);
+
+        var criterion = getCriterion();
+        var result = criterion.calculate(series, record);
+
+        var totalDuration = totalDuration(series);
+        var accumulatedDuration = record.getPositions()
+                .stream()
+                .mapToLong(p -> positionDuration(series, p.getEntry().getIndex(),
+                        p.isClosed() ? p.getExit().getIndex() : series.getEndIndex()))
+                .sum();
+        var expectedPercentage = getExpectedPercentage(totalDuration, accumulatedDuration);
+        var expected = numFactory.numOf(expectedPercentage);
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenRecordHasNoPositions() {
+        var series = buildSeries(4, Duration.ofHours(1));
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, new BaseTradingRecord()));
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenSeriesIsEmpty() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+        var criterion = getCriterion();
+
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, new Position()));
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, new BaseTradingRecord()));
+    }
+
+    @Test
+    public void betterThanPrefersSmallerPercentage() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.numOf(20), numFactory.numOf(40)));
+        assertFalse(criterion.betterThan(numFactory.numOf(60), numFactory.numOf(30)));
+    }
+
+    private BarSeries buildSeries(int barCount, Duration barDuration) {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+        for (var i = 0; i < barCount; i++) {
+            series.barBuilder()
+                    .timePeriod(barDuration)
+                    .closePrice(numFactory.zero())
+                    .openPrice(numFactory.zero())
+                    .highPrice(numFactory.zero())
+                    .lowPrice(numFactory.zero())
+                    .volume(numFactory.zero())
+                    .trades(0)
+                    .add();
+        }
+        return series;
+    }
+
+    private static long totalDuration(BarSeries series) {
+        return ChronoUnit.NANOS.between(series.getFirstBar().getBeginTime(), series.getLastBar().getEndTime());
+    }
+
+    private static long positionDuration(BarSeries series, int entryIndex, int exitIndex) {
+        var entryStart = series.getBar(entryIndex).getBeginTime();
+        var exitEnd = series.getBar(exitIndex).getEndTime();
+        return ChronoUnit.NANOS.between(entryStart, exitEnd);
+    }
+
+    private static double getExpectedPercentage(long totalDuration, double positionDuration) {
+        return totalDuration == 0 ? 0 : positionDuration / totalDuration;
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/commissions/CommissionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/commissions/CommissionsCriterionTest.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.commissions;
+
+import java.util.stream.Stream;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.analysis.cost.FixedTransactionCostModel;
+import org.ta4j.core.analysis.cost.ZeroCostModel;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class CommissionsCriterionTest extends AbstractCriterionTest {
+
+    public CommissionsCriterionTest(NumFactory numFactory) {
+        super(params -> new CommissionsCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateForOpenPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 110, 120).build();
+        var commission = 1.5;
+        var costModel = new FixedTransactionCostModel(commission);
+        var record = new BaseTradingRecord(TradeType.BUY, costModel, new ZeroCostModel());
+        var amount = numFactory.one();
+
+        record.enter(0, series.getFirstBar().getClosePrice(), amount);
+        var openPosition = record.getCurrentPosition();
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(commission), criterion.calculate(series, openPosition));
+    }
+
+    @Test
+    public void calculateReturnsCommissionForClosedPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120).build();
+        var costModel = new FixedTransactionCostModel(2.0);
+        var amount = numFactory.one();
+
+        var entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount, costModel);
+        var exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount, costModel);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        var result = criterion.calculate(series, position);
+
+        assertNumEquals(costModel.calculate(position), result);
+    }
+
+    @Test
+    public void calculateSumsPositionsFromRecord() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 110, 120, 130, 140).build();
+        var costModel = new FixedTransactionCostModel(1.0);
+        var record = new BaseTradingRecord(TradeType.BUY, costModel, new ZeroCostModel());
+        var amount = numFactory.one();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        record.exit(1, series.getBar(1).getClosePrice(), amount);
+
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        record.exit(3, series.getBar(3).getClosePrice(), amount);
+
+        record.enter(4, series.getBar(4).getClosePrice(), amount);
+
+        var criterion = getCriterion();
+        var result = criterion.calculate(series, record);
+
+        var expected = Stream.concat(record.getPositions().stream(), Stream.of(record.getCurrentPosition()))
+                .map(p -> record.getTransactionCostModel().calculate(p))
+                .reduce(numFactory.zero(), Num::plus);
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void betterThanPrefersLowerCommission() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.one(), numFactory.two()));
+        assertFalse(criterion.betterThan(numFactory.two(), numFactory.one()));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/commissions/CommissionsImpactPercentageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/commissions/CommissionsImpactPercentageCriterionTest.java
@@ -1,0 +1,183 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.commissions;
+
+import java.util.stream.Stream;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.analysis.cost.FixedTransactionCostModel;
+import org.ta4j.core.analysis.cost.ZeroCostModel;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class CommissionsImpactPercentageCriterionTest extends AbstractCriterionTest {
+
+    public CommissionsImpactPercentageCriterionTest(NumFactory numFactory) {
+        super(params -> new CommissionsImpactPercentageCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsPercentageForPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120).build();
+        var costModel = new FixedTransactionCostModel(1.5);
+        var amount = numFactory.one();
+
+        var entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount, costModel);
+        var exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount, costModel);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        var result = criterion.calculate(series, position);
+
+        var gross = position.getGrossProfit().abs();
+        var commission = position.getPositionCost().abs();
+        var expected = commission.dividedBy(gross);
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenGrossIsZero() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 100).build();
+        var costModel = new FixedTransactionCostModel(2.0);
+        var amount = numFactory.one();
+
+        var entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount, costModel);
+        var exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount, costModel);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculateReturnsZeroForNewPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120).build();
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, new Position()));
+    }
+
+    @Test
+    public void calculateUsesAggregatedProfitAndCommissionFromRecord() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120, 90, 80, 70).build();
+        var costModel = new FixedTransactionCostModel(1.0);
+        var record = new BaseTradingRecord(TradeType.BUY, costModel, new ZeroCostModel());
+        var amount = numFactory.one();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        record.exit(1, series.getBar(1).getClosePrice(), amount);
+
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        record.exit(3, series.getBar(3).getClosePrice(), amount);
+
+        record.enter(4, series.getBar(4).getClosePrice(), amount);
+
+        var criterion = getCriterion();
+        var result = criterion.calculate(series, record);
+
+        var zero = numFactory.zero();
+        var totalGross = record.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(Position::getGrossProfit)
+                .reduce(zero, Num::plus)
+                .abs();
+        var totalCommission = Stream.concat(record.getPositions().stream(), Stream.of(record.getCurrentPosition()))
+                .map(p -> record.getTransactionCostModel().calculate(p).abs())
+                .reduce(zero, Num::plus);
+        var expected = totalGross.isZero() ? zero : totalCommission.dividedBy(totalGross);
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateReturnsPercentageWhenAggregatedGrossIsNegative() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 110, 120, 90).build();
+        var costModel = new FixedTransactionCostModel(0.75);
+        var record = new BaseTradingRecord(TradeType.BUY, costModel, new ZeroCostModel());
+        var amount = numFactory.one();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        record.exit(1, series.getBar(1).getClosePrice(), amount);
+
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        record.exit(3, series.getBar(3).getClosePrice(), amount);
+
+        var criterion = getCriterion();
+        var result = criterion.calculate(series, record);
+
+        var totalGross = record.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(Position::getGrossProfit)
+                .reduce(numFactory.zero(), Num::plus)
+                .abs();
+        var totalCommission = record.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(p -> record.getTransactionCostModel().calculate(p).abs())
+                .reduce(numFactory.zero(), Num::plus);
+        var expected = totalCommission.dividedBy(totalGross);
+
+        assertTrue(record.getPositions()
+                .stream()
+                .map(Position::getGrossProfit)
+                .reduce(numFactory.zero(), Num::plus)
+                .isNegative());
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenRecordGrossIsZero() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120, 130, 110).build();
+        var costModel = new FixedTransactionCostModel(0.5);
+        var record = new BaseTradingRecord(TradeType.BUY, costModel, new ZeroCostModel());
+        var amount = numFactory.one();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        record.exit(1, series.getBar(1).getClosePrice(), amount);
+
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        record.exit(3, series.getBar(3).getClosePrice(), amount);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void betterThanPrefersLowerImpact() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.one(), numFactory.two()));
+        assertFalse(criterion.betterThan(numFactory.two(), numFactory.one()));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxConsecutiveLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxConsecutiveLossCriterionTest.java
@@ -1,0 +1,130 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+public class MaxConsecutiveLossCriterionTest extends AbstractCriterionTest {
+
+    public MaxConsecutiveLossCriterionTest(NumFactory numFactory) {
+        super(params -> new MaxConsecutiveLossCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsLossForLosingPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 90).build();
+        var amount = numFactory.one();
+        var entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        var exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(-10), criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculateReturnsZeroForWinningOrOpenPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 110, 120).build();
+        var amount = numFactory.one();
+        var winEntry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        var winExit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var winningPosition = new Position(winEntry, winExit);
+
+        var record = new BaseTradingRecord();
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        var openPosition = record.getCurrentPosition();
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, winningPosition));
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, openPosition));
+    }
+
+    @Test
+    public void calculateReturnsZeroForRecordWithoutLosses() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(100, 110, 120, 130, 140, 150)
+                .build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(100), amount);
+        record.exit(1, numFactory.numOf(110), amount); // +10
+
+        record.enter(2, numFactory.numOf(115), amount);
+        record.exit(3, numFactory.numOf(125), amount); // +10
+
+        record.enter(4, numFactory.numOf(140), amount);
+        record.exit(5, numFactory.numOf(140), amount); // 0
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void calculateIdentifiesWorstConsecutiveLoss() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+                .build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(10), amount);
+        record.exit(1, numFactory.numOf(9), amount); // -1
+
+        record.enter(2, numFactory.numOf(11), amount);
+        record.exit(3, numFactory.numOf(9), amount); // -2 (streak total -3)
+
+        record.enter(4, numFactory.numOf(8), amount);
+        record.exit(5, numFactory.numOf(11), amount); // +3 resets streak
+
+        record.enter(6, numFactory.numOf(7), amount);
+        record.exit(7, numFactory.numOf(3), amount); // -4
+
+        record.enter(8, numFactory.numOf(6), amount);
+        record.exit(9, numFactory.numOf(5), amount); // -1 -> cumulative -5
+
+        record.enter(10, numFactory.numOf(5), amount);
+        record.exit(11, numFactory.numOf(3), amount); // -2 -> cumulative -7
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(-7), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void betterThanPrefersSmallerLoss() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.numOf(-2), numFactory.numOf(-5)));
+        assertFalse(criterion.betterThan(numFactory.numOf(-6), numFactory.numOf(-3)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxConsecutiveProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxConsecutiveProfitCriterionTest.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+public class MaxConsecutiveProfitCriterionTest extends AbstractCriterionTest {
+
+    public MaxConsecutiveProfitCriterionTest(NumFactory numFactory) {
+        super(params -> new MaxConsecutiveProfitCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsProfitForWinningPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120).build();
+        var amount = numFactory.one();
+        var entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        var exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(20), criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculateReturnsZeroForLosingOrOpenPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 90, 80).build();
+        var amount = numFactory.one();
+        var lossEntry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        var lossExit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var losingPosition = new Position(lossEntry, lossExit);
+
+        var record = new BaseTradingRecord();
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        var openPosition = record.getCurrentPosition();
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, losingPosition));
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, openPosition));
+    }
+
+    @Test
+    public void calculateReturnsZeroForRecordWithOnlyLosses() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 95, 90, 85).build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        record.exit(1, series.getBar(1).getClosePrice(), amount); // -5
+
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        record.exit(3, series.getBar(3).getClosePrice(), amount); // -5
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void calculateIdentifiesBestConsecutiveProfit() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+                .build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(10), amount);
+        record.exit(1, numFactory.numOf(12), amount); // +2
+
+        record.enter(2, numFactory.numOf(8), amount);
+        record.exit(3, numFactory.numOf(10), amount); // +2 -> streak 4
+
+        record.enter(4, numFactory.numOf(9), amount);
+        record.exit(5, numFactory.numOf(7), amount); // -2 resets
+
+        record.enter(6, numFactory.numOf(6), amount);
+        record.exit(7, numFactory.numOf(9), amount); // +3
+
+        record.enter(8, numFactory.numOf(5), amount);
+        record.exit(9, numFactory.numOf(8), amount); // +3 -> streak 6
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(6), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void betterThanPrefersGreaterProfit() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.numOf(5), numFactory.numOf(3)));
+        assertFalse(criterion.betterThan(numFactory.numOf(1), numFactory.numOf(4)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxPositionNetLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxPositionNetLossCriterionTest.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+public class MaxPositionNetLossCriterionTest extends AbstractCriterionTest {
+
+    public MaxPositionNetLossCriterionTest(NumFactory numFactory) {
+        super(params -> new MaxPositionNetLossCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsNetProfitOfPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 90).build();
+        var amount = numFactory.one();
+        var entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        var exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(-10), criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculateFindsMostNegativeClosedPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1, 2, 3, 4, 5, 6).build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(10), amount);
+        record.exit(1, numFactory.numOf(8), amount); // -2
+
+        record.enter(2, numFactory.numOf(6), amount);
+        record.exit(3, numFactory.numOf(11), amount); // +5
+
+        record.enter(4, numFactory.numOf(7), amount);
+        record.exit(5, numFactory.numOf(6), amount); // -1
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(-2), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenNoLosses() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1, 2, 3, 4).build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(5), amount);
+        record.exit(1, numFactory.numOf(7), amount); // +2
+
+        record.enter(2, numFactory.numOf(6), amount);
+        record.exit(3, numFactory.numOf(9), amount); // +3
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void betterThanPrefersSmallerLoss() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.numOf(-1), numFactory.numOf(-3)));
+        assertFalse(criterion.betterThan(numFactory.numOf(-4), numFactory.numOf(-2)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxPositionNetProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxPositionNetProfitCriterionTest.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+public class MaxPositionNetProfitCriterionTest extends AbstractCriterionTest {
+
+    public MaxPositionNetProfitCriterionTest(NumFactory numFactory) {
+        super(params -> new MaxPositionNetProfitCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsNetProfitOfPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 130).build();
+        var amount = numFactory.one();
+        var entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        var exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(30), criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculateFindsLargestClosedProfit() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1, 2, 3, 4, 5, 6).build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(5), amount);
+        record.exit(1, numFactory.numOf(7), amount); // +2
+
+        record.enter(2, numFactory.numOf(6), amount);
+        record.exit(3, numFactory.numOf(11), amount); // +5
+
+        record.enter(4, numFactory.numOf(8), amount);
+        record.exit(5, numFactory.numOf(6), amount); // -2
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(5), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenNoProfits() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1, 2, 3, 4).build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(10), amount);
+        record.exit(1, numFactory.numOf(7), amount); // -3
+
+        record.enter(2, numFactory.numOf(9), amount);
+        record.exit(3, numFactory.numOf(6), amount); // -3
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void betterThanPrefersGreaterProfit() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.numOf(4), numFactory.numOf(2)));
+        assertFalse(criterion.betterThan(numFactory.numOf(1), numFactory.numOf(3)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/SMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/SMAIndicatorTest.java
@@ -66,6 +66,39 @@ public class SMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
     }
 
     @Test
+    public void ensureCountOfUnstableBarsAddsToCountOfUnstableBarsOfPreviousIndicator() {
+        var closePrice = new ClosePriceIndicator(data);
+        var firstSMAindicator = new SMAIndicator(closePrice, 2);
+        var secondSMAindicator = new SMAIndicator(firstSMAindicator, 3);
+
+        assertEquals(1, firstSMAindicator.getCountOfUnstableBars());
+        assertNumEquals(1.5, firstSMAindicator.getValue(1));
+        assertNumEquals(2.5, firstSMAindicator.getValue(2));
+        assertNumEquals(3.5, firstSMAindicator.getValue(3));
+        assertNumEquals(3.5, firstSMAindicator.getValue(4));
+        assertNumEquals(3.5, firstSMAindicator.getValue(5));
+        assertNumEquals(4.5, firstSMAindicator.getValue(6));
+        assertNumEquals(4.5, firstSMAindicator.getValue(7));
+        assertNumEquals(3.5, firstSMAindicator.getValue(8));
+        assertNumEquals(3, firstSMAindicator.getValue(9));
+        assertNumEquals(3.5, firstSMAindicator.getValue(10));
+        assertNumEquals(3.5, firstSMAindicator.getValue(11));
+        assertNumEquals(2.5, firstSMAindicator.getValue(12));
+
+        assertEquals(3, secondSMAindicator.getCountOfUnstableBars());
+        assertNumEquals(2.5, secondSMAindicator.getValue(3));
+        assertNumEquals((2.5 + 3.5 + 3.5) / 3, secondSMAindicator.getValue(4));
+        assertNumEquals(3.5, secondSMAindicator.getValue(5));
+        assertNumEquals((3.5 + 3.5 + 4.5) / 3, secondSMAindicator.getValue(6));
+        assertNumEquals((3.5 + 4.5 + 4.5) / 3, secondSMAindicator.getValue(7));
+        assertNumEquals((4.5 + 4.5 + 3.5) / 3, secondSMAindicator.getValue(8));
+        assertNumEquals((4.5 + 3.5 + 3) / 3, secondSMAindicator.getValue(9));
+        assertNumEquals((3.5 + 3 + 3.5) / 3, secondSMAindicator.getValue(10));
+        assertNumEquals((3 + 3.5 + 3.5) / 3, secondSMAindicator.getValue(11));
+        assertNumEquals((3.5 + 3.5 + 2.5) / 3, secondSMAindicator.getValue(12));
+    }
+
+    @Test
     public void usingBarCount3UsingClosePrice() {
         Indicator<Num> indicator = getIndicator(new ClosePriceIndicator(data), 3);
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
@@ -38,8 +38,9 @@ import static org.ta4j.core.indicators.pivotpoints.TimeLevel.YEAR;
 import static org.ta4j.core.num.NaN.NaN;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import org.junit.Before;
@@ -606,11 +607,13 @@ public class PivotPointIndicatorTest {
                 2017-10-06,22:00:00,172.24,172.37,172.16,172.23,1062537,0
                 """;
 
-        var dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:s z");
+        var dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:s");
+        var zone = ZoneId.of("America/Los_Angeles");
         series5Minutes = new MockBarSeriesBuilder().withName("FB_5_minutes").build();
         rawData5Minutes.lines().forEach(aDataLine -> {
             var barData = aDataLine.split(",");
-            var date = ZonedDateTime.parse(barData[0] + " " + barData[1] + " PST", dtf).toInstant();
+            var local = LocalDateTime.parse(barData[0] + " " + barData[1], dtf);
+            var date = local.atZone(zone).toInstant();
             var open = Double.parseDouble(barData[2]);
             var high = Double.parseDouble(barData[3]);
             var low = Double.parseDouble(barData[4]);
@@ -807,11 +810,13 @@ public class PivotPointIndicatorTest {
                 2017-10-06,22:00:00,171.67,172.37,171.55,172.23,2317180,0
                 """;
 
-        var dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:s z");
+        var dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:s");
+        var zone = ZoneId.of("America/Los_Angeles");
         series1Hours = new MockBarSeriesBuilder().withName("FB_1_hours").build();
         rawData1Hours.lines().forEach(aDataLine -> {
             var barData = aDataLine.split(",");
-            var date = ZonedDateTime.parse(barData[0] + " " + barData[1] + " PST", dtf).toInstant();
+            var local = LocalDateTime.parse(barData[0] + " " + barData[1], dtf);
+            var date = local.atZone(zone).toInstant();
             double open = Double.parseDouble(barData[2]);
             double high = Double.parseDouble(barData[3]);
             double low = Double.parseDouble(barData[4]);
@@ -1333,53 +1338,60 @@ public class PivotPointIndicatorTest {
         var r3 = new StandardReversalIndicator(pp, RESISTANCE_3);
 
         // pp
-        assertEquals(pp.getValue(0), NaN);// first bar no data for calculation
+        assertEquals(NaN, pp.getValue(0));// first bar no data for calculation
         // result of calculation for 7-27 bar is not adequate because the previous day
-        // is incomplete..
-        assertNumEquals(Double.valueOf("170.91666666666666"), pp.getValue(170));
+        // is incomplete.
+        assertNumEquals(Double.parseDouble("170.91666666666666"), pp.getValue(170));
 
         // prev last bar
-        assertNumEquals(Double.valueOf("169.20666666666666666666666666667"),
+        assertNumEquals(Double.parseDouble("169.20666666666666666666666666667"),
                 pp.getValue(series5Minutes.getEndIndex() - 80));
 
         // last bar
-        assertNumEquals(Double.valueOf("170.07666666666666666666666666667"), pp.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.parseDouble("170.07666666666666666666666666667"),
+                pp.getValue(series5Minutes.getEndIndex()));
 
         // s1
-        assertEquals(s1.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("167.74333333333333333333333333334"),
+        assertEquals(NaN, s1.getValue(0));
+        assertNumEquals(Double.parseDouble("167.74333333333333333333333333334"),
                 s1.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("168.84333333333333333333333333334"), s1.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.parseDouble("168.84333333333333333333333333334"),
+                s1.getValue(series5Minutes.getEndIndex()));
 
         // s2
-        assertEquals(s2.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("166.82666666666666666666666666667"),
+        assertEquals(NaN, s2.getValue(0));
+        assertNumEquals(Double.parseDouble("166.82666666666666666666666666667"),
                 s2.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("167.36666666666666666666666666667"), s2.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.parseDouble("167.36666666666666666666666666667"),
+                s2.getValue(series5Minutes.getEndIndex()));
 
         // s3
-        assertEquals(s3.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("165.36333333333333333333333333334"),
+        assertEquals(NaN, s3.getValue(0));
+        assertNumEquals(Double.parseDouble("165.36333333333333333333333333334"),
                 s3.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("166.13333333333333333333333333334"), s3.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.parseDouble("166.13333333333333333333333333334"),
+                s3.getValue(series5Minutes.getEndIndex()));
 
         // r1
-        assertEquals(r1.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("170.12333333333333333333333333334"),
+        assertEquals(NaN, r1.getValue(0));
+        assertNumEquals(Double.parseDouble("170.12333333333333333333333333334"),
                 r1.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("171.55333333333333333333333333334"), r1.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.parseDouble("171.55333333333333333333333333334"),
+                r1.getValue(series5Minutes.getEndIndex()));
 
         // r2
-        assertEquals(r2.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("171.58666666666666666666666666667"),
+        assertEquals(NaN, r2.getValue(0));
+        assertNumEquals(Double.parseDouble("171.58666666666666666666666666667"),
                 r2.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("172.78666666666666666666666666667"), r2.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.parseDouble("172.78666666666666666666666666667"),
+                r2.getValue(series5Minutes.getEndIndex()));
 
         // r3
-        assertEquals(r3.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("172.50333333333333333333333333334"),
+        assertEquals(NaN, r3.getValue(0));
+        assertNumEquals(Double.parseDouble("172.50333333333333333333333333334"),
                 r3.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("174.26333333333333333333333333334"), r3.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.parseDouble("174.26333333333333333333333333334"),
+                r3.getValue(series5Minutes.getEndIndex()));
 
         var deMarkpp = new DeMarkPivotPointIndicator(series5Minutes, DAY);
         var deMarkR1 = new DeMarkReversalIndicator(deMarkpp, DeMarkReversalIndicator.DeMarkPivotLevel.RESISTANCE);
@@ -1399,14 +1411,14 @@ public class PivotPointIndicatorTest {
     public void PivotPointTestWeeklyBarCount() {
         var pp = new PivotPointIndicator(series1Hours, TimeLevel.WEEK);
 
-        assertEquals(pp.getValue(0), NaN);// first bar no data for
-        assertEquals(pp.getValue(1), NaN);// first bar no data for calculation
-        assertEquals(pp.getValue(6), NaN);// first bar no data for calculation
+        assertEquals(NaN, pp.getValue(0));// first bar no data for
+        assertEquals(NaN, pp.getValue(1));// first bar no data for calculation
+        assertEquals(NaN, pp.getValue(6));// first bar no data for calculation
         // result of calculation for second bar is not adequate because the previous day
         // is incomplete
-        assertNumEquals(Double.valueOf("172.08166"), pp.getValue(28));
-        assertNumEquals(Double.valueOf("170.93666"), pp.getValue(series1Hours.getEndIndex() - 36)); // prev last bar
-        assertNumEquals(Double.valueOf("168.0100"), pp.getValue(series1Hours.getEndIndex())); // last bar
+        assertNumEquals(Double.parseDouble("172.08166"), pp.getValue(28));
+        assertNumEquals(Double.parseDouble("170.93666"), pp.getValue(series1Hours.getEndIndex() - 36)); // prev last bar
+        assertNumEquals(Double.parseDouble("168.0100"), pp.getValue(series1Hours.getEndIndex())); // last bar
 
         var fibR3 = new FibonacciReversalIndicator(pp, 1, FibonacciReversalIndicator.FibReversalTyp.RESISTANCE);
         var fibR2 = new FibonacciReversalIndicator(pp, 0.618, FibonacciReversalIndicator.FibReversalTyp.RESISTANCE);
@@ -1415,12 +1427,12 @@ public class PivotPointIndicatorTest {
         var fibS2 = new FibonacciReversalIndicator(pp, 0.618, FibonacciReversalIndicator.FibReversalTyp.SUPPORT);
         var fibS3 = new FibonacciReversalIndicator(pp, 1, FibonacciReversalIndicator.FibReversalTyp.SUPPORT);
 
-        assertEquals(fibR3.getValue(series1Hours.getBeginIndex()), NaN);
-        assertEquals(fibR2.getValue(1), NaN);
-        assertEquals(fibR1.getValue(2), NaN);
-        assertEquals(fibS1.getValue(6), NaN);
-        assertEquals(fibS2.getValue(series1Hours.getBeginIndex()), NaN);
-        assertEquals(fibS3.getValue(6), NaN);
+        assertEquals(NaN, fibR3.getValue(series1Hours.getBeginIndex()));
+        assertEquals(NaN, fibR2.getValue(1));
+        assertEquals(NaN, fibR1.getValue(2));
+        assertEquals(NaN, fibS1.getValue(6));
+        assertEquals(NaN, fibS2.getValue(series1Hours.getBeginIndex()));
+        assertEquals(NaN, fibS3.getValue(6));
 
         assertEquals(fibR3.getValue(series1Hours.getEndIndex()),
                 pp.getValue(series1Hours.getEndIndex())
@@ -1474,7 +1486,7 @@ public class PivotPointIndicatorTest {
         assertNumEquals(170.5075, deMarkpp.getValue(series1Hours.getEndIndex() - 50));
         assertNumEquals(171.795, deMarkR1.getValue(series1Hours.getEndIndex() - 50));
         assertNumEquals(167.965, deMarkS1.getValue(series1Hours.getEndIndex() - 50));
-        assertNumEquals(168.9225, deMarkpp.getValue(series1Hours.getEndIndex())); // June 61th 2017
+        assertNumEquals(168.9225, deMarkpp.getValue(series1Hours.getEndIndex()));
         assertNumEquals(176.285, deMarkR1.getValue(series1Hours.getEndIndex()));
         assertNumEquals(166.185, deMarkS1.getValue(series1Hours.getEndIndex()));
     }
@@ -1490,48 +1502,48 @@ public class PivotPointIndicatorTest {
         var r3 = new StandardReversalIndicator(pp, RESISTANCE_3);
 
         // pp
-        assertEquals(pp.getValue(0), NaN);
-        assertEquals(pp.getValue(19), NaN); // no previous month for calculation
-        assertNumEquals(Double.valueOf("126.32333"), pp.getValue(20));
-        assertNumEquals(Double.valueOf("134.3415333"), pp.getValue(39));
-        assertNumEquals(Double.valueOf("150.67999"), pp.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("164.18000"), pp.getValue(series1Days.getEndIndex()));
+        assertEquals(NaN, pp.getValue(0));
+        assertEquals(NaN, pp.getValue(19)); // no previous month for calculation
+        assertNumEquals(Double.parseDouble("126.32333"), pp.getValue(20));
+        assertNumEquals(Double.parseDouble("134.3415333"), pp.getValue(39));
+        assertNumEquals(Double.parseDouble("150.67999"), pp.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.parseDouble("164.18000"), pp.getValue(series1Days.getEndIndex()));
 
         // s1
-        assertEquals(s1.getValue(0), NaN);
-        assertEquals(s1.getValue(19), NaN); // no previous month
-        assertNumEquals(Double.valueOf("144.8599999"), s1.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("152.87"), s1.getValue(series1Days.getEndIndex()));
+        assertEquals(NaN, s1.getValue(0));
+        assertEquals(NaN, s1.getValue(19)); // no previous month
+        assertNumEquals(Double.parseDouble("144.8599999"), s1.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.parseDouble("152.87"), s1.getValue(series1Days.getEndIndex()));
 
         // s2
-        assertEquals(s2.getValue(0), NaN);
-        assertEquals(s2.getValue(19), NaN); // no previous month
-        assertNumEquals(Double.valueOf("138.73999999"), s2.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("136.49000"), s2.getValue(series1Days.getEndIndex()));
+        assertEquals(NaN, s2.getValue(0));
+        assertEquals(NaN, s2.getValue(19)); // no previous month
+        assertNumEquals(Double.parseDouble("138.73999999"), s2.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.parseDouble("136.49000"), s2.getValue(series1Days.getEndIndex()));
 
         // s3
-        assertEquals(s3.getValue(0), NaN);
-        assertEquals(s3.getValue(19), NaN); // no previous month
-        assertNumEquals(Double.valueOf("132.92"), s3.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("125.18"), s3.getValue(series1Days.getEndIndex()));
+        assertEquals(NaN, s3.getValue(0));
+        assertEquals(NaN, s3.getValue(19)); // no previous month
+        assertNumEquals(Double.parseDouble("132.92"), s3.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.parseDouble("125.18"), s3.getValue(series1Days.getEndIndex()));
 
         // r1
-        assertEquals(r1.getValue(0), NaN);
-        assertEquals(r1.getValue(19), NaN); // no previous month
-        assertNumEquals(Double.valueOf("156.79999"), r1.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("180.56000"), r1.getValue(series1Days.getEndIndex()));
+        assertEquals(NaN, r1.getValue(0));
+        assertEquals(NaN, r1.getValue(19)); // no previous month
+        assertNumEquals(Double.parseDouble("156.79999"), r1.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.parseDouble("180.56000"), r1.getValue(series1Days.getEndIndex()));
 
         // r2
-        assertEquals(r2.getValue(0), NaN);
-        assertEquals(r2.getValue(19), NaN); // no previous month
-        assertNumEquals(Double.valueOf("162.61999"), r2.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("191.87000"), r2.getValue(series1Days.getEndIndex()));
+        assertEquals(NaN, r2.getValue(0));
+        assertEquals(NaN, r2.getValue(19)); // no previous month
+        assertNumEquals(Double.parseDouble("162.61999"), r2.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.parseDouble("191.87000"), r2.getValue(series1Days.getEndIndex()));
 
         // r3
-        assertEquals(r3.getValue(0), NaN);
-        assertEquals(r3.getValue(19), NaN); // no previous month
-        assertNumEquals(Double.valueOf("168.74"), r3.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("208.25000"), r3.getValue(series1Days.getEndIndex()));
+        assertEquals(NaN, r3.getValue(0));
+        assertEquals(NaN, r3.getValue(19)); // no previous month
+        assertNumEquals(Double.parseDouble("168.74"), r3.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.parseDouble("208.25000"), r3.getValue(series1Days.getEndIndex()));
     }
 
     @Test
@@ -1545,52 +1557,52 @@ public class PivotPointIndicatorTest {
         var r3 = new StandardReversalIndicator(pp, RESISTANCE_3);
 
         // pp
-        assertEquals(pp.getValue(0), NaN);
-        assertEquals(pp.getValue(33), NaN); // no previous year
-        assertNumEquals(Double.valueOf("70.823331"), pp.getValue(series1Weeks.getEndIndex() - 100));
-        assertNumEquals(Double.valueOf("95.77000"), pp.getValue(series1Weeks.getEndIndex() - 40));
-        assertNumEquals(Double.valueOf("112.6400"), pp.getValue(series1Weeks.getEndIndex()));
+        assertEquals(NaN, pp.getValue(0));
+        assertEquals(NaN, pp.getValue(33)); // no previous year
+        assertNumEquals(Double.parseDouble("70.823331"), pp.getValue(series1Weeks.getEndIndex() - 100));
+        assertNumEquals(Double.parseDouble("95.77000"), pp.getValue(series1Weeks.getEndIndex() - 40));
+        assertNumEquals(Double.parseDouble("112.6400"), pp.getValue(series1Weeks.getEndIndex()));
 
         // s1
-        assertEquals(s1.getValue(0), NaN);
-        assertEquals(s1.getValue(33), NaN); // no previous year
-        assertNumEquals(Double.valueOf("59.4766"), s1.getValue(series1Weeks.getEndIndex() - 100));
-        assertNumEquals(Double.valueOf("80.89000"), s1.getValue(series1Weeks.getEndIndex() - 40));
-        assertNumEquals(Double.valueOf("91.7800"), s1.getValue(series1Weeks.getEndIndex()));
+        assertEquals(NaN, s1.getValue(0));
+        assertEquals(NaN, s1.getValue(33)); // no previous year
+        assertNumEquals(Double.parseDouble("59.4766"), s1.getValue(series1Weeks.getEndIndex() - 100));
+        assertNumEquals(Double.parseDouble("80.89000"), s1.getValue(series1Weeks.getEndIndex() - 40));
+        assertNumEquals(Double.parseDouble("91.7800"), s1.getValue(series1Weeks.getEndIndex()));
 
         // s2
-        assertEquals(s2.getValue(0), NaN);
-        assertEquals(s2.getValue(33), NaN); // no previous year
-        assertNumEquals(Double.valueOf("40.5033309"), s2.getValue(series1Weeks.getEndIndex() - 100));
-        assertNumEquals(Double.valueOf("57.11999999"), s2.getValue(series1Weeks.getEndIndex() - 40));
-        assertNumEquals(Double.valueOf("68.510004"), s2.getValue(series1Weeks.getEndIndex()));
+        assertEquals(NaN, s2.getValue(0));
+        assertEquals(NaN, s2.getValue(33)); // no previous year
+        assertNumEquals(Double.parseDouble("40.5033309"), s2.getValue(series1Weeks.getEndIndex() - 100));
+        assertNumEquals(Double.parseDouble("57.11999999"), s2.getValue(series1Weeks.getEndIndex() - 40));
+        assertNumEquals(Double.parseDouble("68.510004"), s2.getValue(series1Weeks.getEndIndex()));
 
         // s3
-        assertEquals(s3.getValue(0), NaN);
-        assertEquals(s3.getValue(33), NaN); // no previous year
-        assertNumEquals(Double.valueOf("29.1566639"), s3.getValue(series1Weeks.getEndIndex() - 100));
-        assertNumEquals(Double.valueOf("42.239999"), s3.getValue(series1Weeks.getEndIndex() - 40));
-        assertNumEquals(Double.valueOf("47.65000"), s3.getValue(series1Weeks.getEndIndex()));
+        assertEquals(NaN, s3.getValue(0));
+        assertEquals(NaN, s3.getValue(33)); // no previous year
+        assertNumEquals(Double.parseDouble("29.1566639"), s3.getValue(series1Weeks.getEndIndex() - 100));
+        assertNumEquals(Double.parseDouble("42.239999"), s3.getValue(series1Weeks.getEndIndex() - 40));
+        assertNumEquals(Double.parseDouble("47.65000"), s3.getValue(series1Weeks.getEndIndex()));
 
         // r1
-        assertEquals(r1.getValue(0), NaN);
-        assertEquals(r1.getValue(33), NaN); // no previous year
-        assertNumEquals(Double.valueOf("89.7966640"), r1.getValue(series1Weeks.getEndIndex() - 100));
-        assertNumEquals(Double.valueOf("119.5400"), r1.getValue(series1Weeks.getEndIndex() - 40));
-        assertNumEquals(Double.valueOf("135.91000"), r1.getValue(series1Weeks.getEndIndex()));
+        assertEquals(NaN, r1.getValue(0));
+        assertEquals(NaN, r1.getValue(33)); // no previous year
+        assertNumEquals(Double.parseDouble("89.7966640"), r1.getValue(series1Weeks.getEndIndex() - 100));
+        assertNumEquals(Double.parseDouble("119.5400"), r1.getValue(series1Weeks.getEndIndex() - 40));
+        assertNumEquals(Double.parseDouble("135.91000"), r1.getValue(series1Weeks.getEndIndex()));
 
         // r2
-        assertEquals(r2.getValue(0), NaN);
-        assertEquals(r2.getValue(33), NaN); // no previous year
-        assertNumEquals(Double.valueOf("101.1433310"), r2.getValue(series1Weeks.getEndIndex() - 100));
-        assertNumEquals(Double.valueOf("134.42000"), r2.getValue(series1Weeks.getEndIndex() - 40));
-        assertNumEquals(Double.valueOf("156.76999"), r2.getValue(series1Weeks.getEndIndex()));
+        assertEquals(NaN, r2.getValue(0));
+        assertEquals(NaN, r2.getValue(33)); // no previous year
+        assertNumEquals(Double.parseDouble("101.1433310"), r2.getValue(series1Weeks.getEndIndex() - 100));
+        assertNumEquals(Double.parseDouble("134.42000"), r2.getValue(series1Weeks.getEndIndex() - 40));
+        assertNumEquals(Double.parseDouble("156.76999"), r2.getValue(series1Weeks.getEndIndex()));
 
         // r3
-        assertEquals(r3.getValue(0), NaN);
-        assertEquals(r3.getValue(33), NaN); // no previous year
-        assertNumEquals(Double.valueOf("120.116664"), r3.getValue(series1Weeks.getEndIndex() - 100));
-        assertNumEquals(Double.valueOf("158.19000"), r3.getValue(series1Weeks.getEndIndex() - 40));
-        assertNumEquals(Double.valueOf("180.03999"), r3.getValue(series1Weeks.getEndIndex()));
+        assertEquals(NaN, r3.getValue(0));
+        assertEquals(NaN, r3.getValue(33)); // no previous year
+        assertNumEquals(Double.parseDouble("120.116664"), r3.getValue(series1Weeks.getEndIndex() - 100));
+        assertNumEquals(Double.parseDouble("158.19000"), r3.getValue(series1Weeks.getEndIndex() - 40));
+        assertNumEquals(Double.parseDouble("180.03999"), r3.getValue(series1Weeks.getEndIndex()));
     }
 }


### PR DESCRIPTION

Fixes #.

Changes proposed in this pull request:
- the SMA indicator (calculating on another indicator) should return the unstable bars of the indicator the sma is calculating on plus its own unstable bars
- if this PR is considered useful and merged I will happily volunteer to fix the other affected indicators as well 
- 

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
